### PR TITLE
PostCSS config still needed to compile tailwind

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}


### PR DESCRIPTION
Hey @duncanmcclean 
I came across this while running a test deploy to Laravel Cloud. Tailwind wasn't compiling in the builds and it looks like the postcss config was needed.